### PR TITLE
stop panic if using oneof

### DIFF
--- a/protoc-gen-go/retag/retag.go
+++ b/protoc-gen-go/retag/retag.go
@@ -52,6 +52,7 @@ func (r *retag) getStructTags(filename string) {
 
 	r.tags = make(map[string]string)
 	var begin bool
+	var oneof bool
 	var comment bool
 	var msgName string
 	reader := bufio.NewReader(file)
@@ -74,9 +75,19 @@ func (r *retag) getStructTags(filename string) {
 			continue
 		}
 
+		if strings.HasPrefix(strings.TrimSpace(string(line)), "oneof") {
+			oneof = true
+			continue
+		}
+
 		if strings.HasPrefix(strings.TrimSpace(string(line)), "message") {
 			begin = true
 			msgName = strings.Fields(string(line))[1]
+			continue
+		}
+
+		if oneof == true && strings.TrimSpace(string(line))[0] == '}' {
+			oneof = false
 			continue
 		}
 

--- a/protoc-gen-go/retag/retag.go
+++ b/protoc-gen-go/retag/retag.go
@@ -119,7 +119,7 @@ func (r *retag) getStructTags(filename string) {
 	}
 }
 
-var reFnT *regexp.Regexp = regexp.MustCompile(`^\s*[^\s]*\s*([^\s]+)\s*([^\s]+)\s*=\s*\d+\s*;\s*(//.*(json:"[^"]+").*)?`)
+var reFnT *regexp.Regexp = regexp.MustCompile(`^\s*(?:repeated)?\s*(map<[^>]+>|[^\s]+)\s*([^\s]+)\s*=\s*\d+\s*;\s*(//.*(json:"[^"]+").*)?`)
 
 func getFieldTag(line string, msgName string) (field string, tag string) {
 	m := reFnT.FindAllStringSubmatch(line, 4)
@@ -130,8 +130,10 @@ func getFieldTag(line string, msgName string) (field string, tag string) {
 	if m[0][4] != "" {
 		tag = m[0][4]
 	} else {
+		// fmt.Fprintf(os.Stderr, "no match %v %v\n", m, line)
 		tag = fmt.Sprintf(`json:"%s"`, m[0][2])
 	}
+	// fmt.Fprintf(os.Stderr, "2. field %v  tag %v\n", field, tag)
 	return
 }
 

--- a/protoc-gen-go/retag/retag.go
+++ b/protoc-gen-go/retag/retag.go
@@ -63,6 +63,10 @@ func (r *retag) getStructTags(filename string) {
 			break
 		}
 
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+
 		if strings.HasPrefix(strings.TrimSpace(string(line)), "/*") {
 			comment = true
 		}


### PR DESCRIPTION
@qianlnk thanks for retag, I'm finding it really useful.

It currently panics when using `oneof`s. Here a fix, but it would be really nice if we could put tags on the oneof and the containing field.